### PR TITLE
Adding "extraParams to getRequestToken call

### DIFF
--- a/lib/fitbit.js
+++ b/lib/fitbit.js
@@ -55,8 +55,8 @@ module.exports = FitbitApiClient;
 // ---
 
 // Fetches a request token and runs callback
-cp.getRequestToken = function (callback) {
-  this._oauth.getOAuthRequestToken(callback);
+cp.getRequestToken = function (extraParams, callback) {
+  this._oauth.getOAuthRequestToken(extraParams, callback);
 };
 
 // Returns the authorization url required for obtaining an access token


### PR DESCRIPTION
Updated `getRequestToken` in the client to match the interface in oauth's `getOAuthRequestToken`, so to pass extra arguments when needed.
